### PR TITLE
Warning and notice fixes

### DIFF
--- a/custom-taxonomies.php
+++ b/custom-taxonomies.php
@@ -45,7 +45,7 @@ abstract class CustomTaxonomy {
 
 	public function options($key){
 		$vars = get_object_vars($this);
-		return $vars[$key];
+		return isset( $vars[$key] ) ? $vars[$key] : null;
 	}
 
 	public function labels() {

--- a/functions/config.php
+++ b/functions/config.php
@@ -53,9 +53,9 @@ define('THEME_OPTIONS_NAME', 'theme');
 define('THEME_OPTIONS_PAGE_TITLE', 'Theme Options');
 
 $theme_options = get_option(THEME_OPTIONS_NAME);
-define('GA_ACCOUNT', $theme_options['ga_account']);
-define('CB_UID', $theme_options['cb_uid']);
-define('CB_DOMAIN', $theme_options['cb_domain']);
+define('GA_ACCOUNT', isset( $theme_options['ga_account'] ) ? $theme_options['ga_account'] : '' );
+define('CB_UID', isset( $theme_options['cb_uid'] ) ? $theme_options['cb_uid'] : '' );
+define('CB_DOMAIN', isset( $theme_options['cb_domain'] ) ? $theme_options['cb_domain'] : '' );
 
 # Timeout for data grabbed from feeds
 define('FEED_FETCH_TIMEOUT', 10); // seconds

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -358,17 +358,21 @@ function sc_display_recent_updates( $attrs, $content=null ) {
 add_shortcode('display-recent-updates', 'sc_display_recent_updates');
 
 
-function sc_comments($attr, $content=null) {
+function sc_comments( $attr, $content=null ) {
+	$attr = shortcode_atts( array(
+		'title' => ''
+	), $attr, 'comments' );
+
 	ob_start();
-	if ($attr['title']) {
+	if ( !empty( $attr['title'] ) ) {
 	?>
-		<h2 class="border-bottom comments-title"><?php echo $attr['title'] ?></h2>
+		<h2 class="border-bottom comments-title"><?php echo $attr['title']; ?></h2>
 	<?php
 	}
-	comments_template('', true);
+	comments_template( '', true );
 	return ob_get_clean();
 }
-add_shortcode('comments', 'sc_comments');
+add_shortcode( 'comments', 'sc_comments' );
 
 
 function sc_comment_form() {

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -254,6 +254,10 @@ add_shortcode('blockquote', 'sc_blockquote');
  * full-screen background image with parallax effects.
  **/
 function sc_parallax_feature($attrs, $content=null) {
+	$attrs = shortcode_atts( array(
+		'title' => ''
+	), $attrs, 'parallax_feature' );
+
 	$title = $attrs['title'];
 	$feature = !empty( $title ) ? get_page_by_title( $title, 'OBJECT', 'parallax_feature' ) : null;
 

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -18,7 +18,7 @@ add_shortcode('search_form', 'sc_search_form');
  * @author Chris Conover
  **/
 function sc_post_type_search($params=array(), $content='') {
-	$defaults = array(
+	$params = shortcode_atts( array(
 		'post_type_name'         => 'post',
 		'taxonomy'               => 'category',
 		'show_empty_sections'    => false,
@@ -30,9 +30,7 @@ function sc_post_type_search($params=array(), $content='') {
 		'show_sorting'           => True,
 		'default_sorting'        => 'term',
 		'show_sorting'           => True
-	);
-
-	$params = ($params === '') ? $defaults : array_merge($defaults, $params);
+	), $params, 'post-type-search' );
 
 	$params['show_empty_sections'] = (bool)$params['show_empty_sections'];
 	$params['column_count']        = is_numeric($params['column_count']) ? (int)$params['column_count'] : $defaults['column_count'];
@@ -208,9 +206,9 @@ add_shortcode('post-type-search', 'sc_post_type_search');
 * Wrap arbitrary text in <blockquote>
 **/
 function sc_blockquote($attr, $content='') {
-	$source = $attr['source'] ? $attr['source'] : null;
-	$cite = $attr['cite'] ? $attr['cite'] : null;
-	$color = $attr['color'] ? $attr['color'] : null;
+	$source = isset( $attr['source'] ) ? $attr['source'] : null;
+	$cite   = isset( $attr['cite'] ) ? $attr['cite'] : null;
+	$color  = isset( $attr['color'] ) ? $attr['color'] : null;
 
 	$html = '<blockquote';
 	if ($source) {
@@ -451,10 +449,10 @@ add_shortcode( 'social-share-buttons', 'sc_social_share_buttons' );
 
 
 function sc_chart( $attr ) {
-	$id = $attr['id'] ? $attr['id'] : 'custom-chart';
-	$type = $attr['type'] ? $attr['type'] : 'bar';
-	$json = $attr['data'] ? $attr['data'] : '';
-	$options = $attr['options'] ? $attr['options'] : '';
+	$id = isset( $attr['id'] ) ? $attr['id'] : 'custom-chart';
+	$type = isset( $attr['type'] ) ? $attr['type'] : 'bar';
+	$json = isset( $attr['data'] ) ? $attr['data'] : '';
+	$options = isset( $attr['options'] ) ? $attr['options'] : '';
 
 	if ( empty( $json ) ) {
 		return;


### PR DESCRIPTION
Eliminates some notices and warnings thrown due to array values not being set in certain scenarios (usually missing shortcode attributes).

Partially resolves #1, but does not eliminate all notices--we can't really eliminate all of them without refactoring portions of the theme. @jmbarne3, I'll let you decide if you want to leave that issue open or not upon merging this in.